### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ $ sudo adduser $USER dialout
 ### Raspbian
 Similar to Ubuntu.
 
+### Arch Linux
+To use serial in Arch Linux, add yourself to the `uucp` group.
+
+To add yourself to the group:
+```console
+$ sudo gpasswd -a $USER uucp
+```
+Make sure to logout and login again to register the group change.
 
 # Example
 


### PR DESCRIPTION
Added requirements for Arch Linux, to be able to use serial in Arch Linux a user must be in the uucp group.
This will make the library available for more systems.