### PR TITLE
Add exception queues to threads to handle errors in the calling thread.

### DIFF
--- a/crownstone_uart/Exceptions.py
+++ b/crownstone_uart/Exceptions.py
@@ -2,4 +2,31 @@ from enum import Enum
 
 
 class UartError(Enum):
-    NO_CROWNSTONE_UART_DEVICE_AVAILABLE  = "NO_CROWNSTONE_UART_DEVICE_AVAILABLE"
+    """Error types for Uart exceptions."""
+    NO_CROWNSTONE_UART_DEVICE_AVAILABLE = "NO_CROWNSTONE_UART_DEVICE_AVAILABLE"
+
+
+class UartBridgeError(Enum):
+    """Error types for Uart Bridge exceptions."""
+    CANNOT_OPEN_SERIAL_CONTROLLER       = "CANNOT_OPEN_SERIAL_CONTROLLER"
+
+    def __str__(self) -> str:
+        """Return value of the error."""
+        return self.value
+
+
+class UartManagerError(Enum):
+    """Error types for Uart Manager exceptions."""
+    UART_BRIDGE_ERROR                   = "UART_BRIDGE_ERROR"
+
+    def __str__(self) -> str:
+        """Return value of the error."""
+        return self.value
+
+
+class UartBridgeException(Exception):
+    """Raised on errors in the Uart Bridge."""
+    
+
+class UartManagerException(Exception):
+    """Raised on errors in the Uart Manager."""

--- a/crownstone_uart/core/CrownstoneUart.py
+++ b/crownstone_uart/core/CrownstoneUart.py
@@ -1,5 +1,6 @@
 # import signal  # used to catch control C
 import logging
+import queue
 import time
 
 from crownstone_core.protocol.BlePackets import ControlPacket
@@ -28,8 +29,9 @@ class CrownstoneUart:
     def __init__(self):
         self.uartManager = None
         self.running = True
-
-        self.uartManager = UartManager()
+        
+        self.manager_exception_queue = queue.Queue()
+        self.uartManager = UartManager(self.manager_exception_queue)
         self.stoneManager = StoneManager()
 
         self.state = StateHandler()
@@ -46,16 +48,17 @@ class CrownstoneUart:
 
 
 
-    async def initialize_usb(self, port = None, baudrate=230400, writeChunkMaxSize=0):
-        '''
-            writing in chunks solves issues writing to certain JLink chips. A max chunkSize of 64 was found to work well for our case.
-            For normal usage with Crownstones this is not required.
-            writeChunkMaxSize of 0 will not send the payload in chunks
-            :param port:
-            :param baudrate:
-            :param writeChunkMaxSize:
-            :return:
-        '''
+    async def initialize_usb(self, port = None, baudrate=230400, writeChunkMaxSize=0) -> bool:
+        """
+        Initialize a Crownstone serial device. 
+            
+        :param port: serial port of the USB. e.g. '/dev/ttyUSB0' or 'COM3'.
+        :param baudrate: baudrate that should be used for this connection. default is 230400.
+        :param writeChunkMaxSize: writing in chunks solves issues writing to certain JLink chips. A max chunkSize of 64 was found to work well for our case.
+        For normal usage with Crownstones this is not required. a writeChunkMaxSize of 0 will not send the payload in chunks.
+        
+        This method is a coroutine.
+        """
         self.uartManager.config(port, baudrate, writeChunkMaxSize)
 
         result = [False]
@@ -66,21 +69,31 @@ class CrownstoneUart:
         self.uartManager.start()
 
         while not result[0] and self.running:
+            try:
+                exc = self.manager_exception_queue.get(block=False)
+            except queue.Empty:
+                pass
+            else:
+                _LOGGER.warning(f"Error occurred while initializing USB: {exc}, quitting.")
+                # wait for thread to close
+                self.uartManager.join()
+                self.stop()
+                break
+                    
             await asyncio.sleep(0.1)
 
         UartEventBus.unsubscribe(event)
         
 
     def initialize_usb_sync(self, port = None, baudrate=230400, writeChunkMaxSize=0):
-        '''
-            writing in chunks solves issues writing to certain JLink chips. A max chunkSize of 64 was found to work well for our case.
-            For normal usage with Crownstones this is not required.
-            writeChunkMaxSize of 0 will not send the payload in chunks
-            :param port:
-            :param baudrate:
-            :param writeChunkMaxSize:
-            :return:
-        '''
+        """
+        Initialize a Crownstone serial device. 
+            
+        :param port: serial port of the USB. e.g. '/dev/ttyUSB0' or 'COM3'.
+        :param baudrate: baudrate that should be used for this connection. default is 230400.
+        :param writeChunkMaxSize: writing in chunks solves issues writing to certain JLink chips. A max chunkSize of 64 was found to work well for our case.
+        For normal usage with Crownstones this is not required. a writeChunkMaxSize of 0 will not send the payload in chunks.
+        """
         self.uartManager.config(port, baudrate, writeChunkMaxSize)
 
         result = [False]
@@ -93,6 +106,17 @@ class CrownstoneUart:
 
         try:
             while not result[0] and self.running:
+                try:
+                    exc = self.manager_exception_queue.get(block=False)
+                except queue.Empty:
+                    pass
+                else:
+                    _LOGGER.warning(f"Error occurred while initializing USB: {exc[1]}, quitting.")
+                    # wait for thread to close
+                    self.uartManager.join()
+                    self.stop()
+                    break
+                    
                 time.sleep(0.1)
         except KeyboardInterrupt:
             print("\nClosing Crownstone Uart.... Thanks for your time!")

--- a/crownstone_uart/core/CrownstoneUart.py
+++ b/crownstone_uart/core/CrownstoneUart.py
@@ -48,14 +48,14 @@ class CrownstoneUart:
 
 
 
-    async def initialize_usb(self, port = None, baudrate=230400, writeChunkMaxSize=0) -> bool:
+    async def initialize_usb(self, port = None, baudrate=230400, writeChunkMaxSize=0):
         """
         Initialize a Crownstone serial device. 
             
         :param port: serial port of the USB. e.g. '/dev/ttyUSB0' or 'COM3'.
         :param baudrate: baudrate that should be used for this connection. default is 230400.
         :param writeChunkMaxSize: writing in chunks solves issues writing to certain JLink chips. A max chunkSize of 64 was found to work well for our case.
-        For normal usage with Crownstones this is not required. a writeChunkMaxSize of 0 will not send the payload in chunks.
+            For normal usage with Crownstones this is not required. a writeChunkMaxSize of 0 will not send the payload in chunks.
         
         This method is a coroutine.
         """
@@ -71,14 +71,13 @@ class CrownstoneUart:
         while not result[0] and self.running:
             try:
                 exc = self.manager_exception_queue.get(block=False)
-            except queue.Empty:
-                pass
-            else:
+                # log error & wait for thread to close
                 _LOGGER.warning(f"Error occurred while initializing USB: {exc}, quitting.")
-                # wait for thread to close
                 self.uartManager.join()
                 self.stop()
                 break
+            except queue.Empty:
+                pass 
                     
             await asyncio.sleep(0.1)
 
@@ -92,7 +91,7 @@ class CrownstoneUart:
         :param port: serial port of the USB. e.g. '/dev/ttyUSB0' or 'COM3'.
         :param baudrate: baudrate that should be used for this connection. default is 230400.
         :param writeChunkMaxSize: writing in chunks solves issues writing to certain JLink chips. A max chunkSize of 64 was found to work well for our case.
-        For normal usage with Crownstones this is not required. a writeChunkMaxSize of 0 will not send the payload in chunks.
+            For normal usage with Crownstones this is not required. a writeChunkMaxSize of 0 will not send the payload in chunks.
         """
         self.uartManager.config(port, baudrate, writeChunkMaxSize)
 
@@ -108,16 +107,16 @@ class CrownstoneUart:
             while not result[0] and self.running:
                 try:
                     exc = self.manager_exception_queue.get(block=False)
-                except queue.Empty:
-                    pass
-                else:
-                    _LOGGER.warning(f"Error occurred while initializing USB: {exc[1]}, quitting.")
-                    # wait for thread to close
+                    # log error & wait for thread to close
+                    _LOGGER.warning(f"Error occurred while initializing USB: {exc}, quitting.")
                     self.uartManager.join()
                     self.stop()
                     break
+                except queue.Empty:
+                    pass
                     
                 time.sleep(0.1)
+                
         except KeyboardInterrupt:
             print("\nClosing Crownstone Uart.... Thanks for your time!")
             self.stop()

--- a/crownstone_uart/core/uart/UartBridge.py
+++ b/crownstone_uart/core/uart/UartBridge.py
@@ -1,5 +1,4 @@
 import logging
-import queue
 import sys
 import threading
 
@@ -19,6 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 class UartBridge(threading.Thread):
 
     def __init__(self, exception_queue, port, baudrate, writeChunkMaxSize=0):
+        self.bridge_exception_queue = exception_queue
         self.baudrate = baudrate
         self.port = port
         self.writeChunkMaxSize = writeChunkMaxSize
@@ -29,7 +29,6 @@ class UartBridge(threading.Thread):
         self.running = True
         self.parser = UartParser()
         self.eventId = UartEventBus.subscribe(SystemTopics.uartWriteData, self.write_to_uart)
-        self.bridge_exception_queue: queue.Queue = exception_queue
 
         threading.Thread.__init__(self)
 
@@ -41,7 +40,7 @@ class UartBridge(threading.Thread):
         try:
             self.start_serial()
             self.start_reading()
-        except UartBridgeException:
+        except (UartBridgeException, BaseException):
             self.bridge_exception_queue.put(sys.exc_info())
 
 


### PR DESCRIPTION
This PR adds exception queues to the `UartManager` and `UartBridge` threads to be able to handle any exceptions occurring in those threads, in the calling threads.

@AlexDM0 If handshake is not successful and we get receive an exception from the bridge (serial error), do we immediately quit or do we still check the other ports? It currently does the first thing. If a serial error occurs (let's say, no user access to port because not in serial group), it's unlikely it will work for other serial ports anyway.