### PR TITLE
Raise exception in main thread when initialization fails.

### DIFF
--- a/crownstone_uart/Exceptions.py
+++ b/crownstone_uart/Exceptions.py
@@ -15,22 +15,5 @@ class UartBridgeError(Enum):
         return self.value
 
 
-class UartManagerError(Enum):
-    """Error types for Uart Manager exceptions."""
-    UART_BRIDGE_ERROR                   = "UART_BRIDGE_ERROR"
-
-    def __str__(self) -> str:
-        """Return value of the error."""
-        return self.value
-
-
-class UartBridgeException(Exception):
-    """Raised on errors in the Uart Bridge."""
-
-
-class UartManagerException(Exception):
-    """Raised on errors in the Uart Manager."""
-
-
 class UartException(Exception):
-    """Raised on errors while initializing USB."""
+    """Raised on errors in the Uart Manager."""

--- a/crownstone_uart/Exceptions.py
+++ b/crownstone_uart/Exceptions.py
@@ -26,7 +26,11 @@ class UartManagerError(Enum):
 
 class UartBridgeException(Exception):
     """Raised on errors in the Uart Bridge."""
-    
+
 
 class UartManagerException(Exception):
     """Raised on errors in the Uart Manager."""
+
+
+class UartException(Exception):
+    """Raised on errors while initializing USB."""

--- a/crownstone_uart/core/CrownstoneUart.py
+++ b/crownstone_uart/core/CrownstoneUart.py
@@ -21,8 +21,6 @@ from crownstone_uart.core.uart.UartTypes import UartTxType, UartMessageType
 from crownstone_uart.core.uart.uartPackets.UartWrapperPacket import UartWrapperPacket
 from crownstone_uart.topics.SystemTopics import SystemTopics
 
-from crownstone_uart.Exceptions import UartException
-
 _LOGGER = logging.getLogger(__name__)
 
 class CrownstoneUart:
@@ -75,7 +73,7 @@ class CrownstoneUart:
                 exc = self.manager_exception_queue.get(block=False)
                 self.uartManager.join()
                 self.stop()
-                raise UartException(exc)
+                raise exc[0](exc[1])
             except queue.Empty:
                 pass
 
@@ -109,7 +107,7 @@ class CrownstoneUart:
                     exc = self.manager_exception_queue.get(block=False)
                     self.uartManager.join()
                     self.stop()
-                    raise UartException(exc)
+                    raise exc[0](exc[1])
                 except queue.Empty:
                     pass
 

--- a/crownstone_uart/core/CrownstoneUart.py
+++ b/crownstone_uart/core/CrownstoneUart.py
@@ -70,10 +70,10 @@ class CrownstoneUart:
 
         while not result[0] and self.running:
             try:
-                exc = self.manager_exception_queue.get(block=False)
+                exception, exception_value, trace = self.manager_exception_queue.get(block=False)
                 self.uartManager.join()
                 self.stop()
-                raise exc[0](exc[1])
+                raise exception(exception_value)
             except queue.Empty:
                 pass
 

--- a/crownstone_uart/core/uart/UartBridge.py
+++ b/crownstone_uart/core/uart/UartBridge.py
@@ -10,7 +10,7 @@ from crownstone_uart.core.UartEventBus import UartEventBus
 from crownstone_uart.core.uart.UartParser import UartParser
 from crownstone_uart.core.uart.UartReadBuffer import UartReadBuffer
 from crownstone_uart.topics.SystemTopics import SystemTopics
-from crownstone_uart.Exceptions import UartBridgeError, UartBridgeException
+from crownstone_uart.Exceptions import UartBridgeError, UartException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class UartBridge(threading.Thread):
         try:
             self.start_serial()
             self.start_reading()
-        except (UartBridgeException, BaseException):
+        except (UartException, BaseException):
             self.bridge_exception_queue.put(sys.exc_info())
 
 
@@ -61,7 +61,8 @@ class UartBridge(threading.Thread):
             self.serialController.open()
         except OSError or serial.SerialException or KeyboardInterrupt as serial_error:
             self.stop()
-            raise UartBridgeException(f"{UartBridgeError.CANNOT_OPEN_SERIAL_CONTROLLER} -> {serial_error}") from serial_error
+            _LOGGER.error(serial_error)
+            raise UartException(UartBridgeError.CANNOT_OPEN_SERIAL_CONTROLLER, serial_error) from serial_error
 
 
     def start_reading(self):

--- a/crownstone_uart/core/uart/UartManager.py
+++ b/crownstone_uart/core/uart/UartManager.py
@@ -153,9 +153,9 @@ class UartManager(threading.Thread):
             # handle exceptions that happen in thread while initializing
             while not self._uartBridge.started and self.running:
                 try:
-                    exc = bridge_exception_queue.get(block=False)
+                    exception, exception_value, trace = bridge_exception_queue.get(block=False)
                     self._uartBridge.join()
-                    raise exc[0](exc[1])
+                    raise exception(exception_value)
                 except queue.Empty:
                     pass
                     


### PR DESCRIPTION
In the last PR, exceptions were added in the threads, which can then be retrieved in the main thread when one occurs.

However no exception was raised in the main thread in order to act on failures. This PR adds those. Exceptions have also been simplified to `UartException`. An exception happening in the UartBridge thread is now guided to the main thread by raising it again in the calling thread.

Example usage with these changes:
```python
try:
   await uart.initialize_usb("/dev/crownstone")
except UartException as err:
   _LOGGER.error(err)
```

output:
```console
ERROR:(<UartBridgeError.CANNOT_OPEN_SERIAL_CONTROLLER: 'CANNOT_OPEN_SERIAL_CONTROLLER'>, SerialException(2, "could not open port /dev/crownstone: [Errno 2] No such file or directory: '/dev/crownstone'"))
```
In case that port does not exist. 

This change is necessary for allowing manual path setup within Home Assistant, in case a user has not provided a valid path the lib would not be initialized and the user can be notified by catching the exception.